### PR TITLE
MS16-032 Fix

### DIFF
--- a/Sherlock.ps1
+++ b/Sherlock.ps1
@@ -431,7 +431,7 @@ function Find-MS16016 {
 }
 
 function Find-MS16032 {
-
+    echo "Moo"
     # Set the MS Bulletin
     $MSBulletin = "MS16-032"
 
@@ -451,13 +451,15 @@ function Find-MS16032 {
         # Get the Build and Revision
         $Build = [int]$VersionInfo[2]
         $Revision = $VersionInfo[3].Split(" ")[0] # Drop the junk
-
+        echo $Build
+        echo $Revision
+        echo "----"
         # Decide which versions are vulnerable
         switch ( $Build ) {
-            6002 { if ( ( $Revision -In 23000..23909 ) -Or ( $Revison -lt 19598 ) ) { $VulnStatus = "Appears Vulnerable" } } # Confirmed for Windows 2008
+            6002 { if ( $Revison -lt 19598 -Or ( $Revision -ge 23000 -And $Revision -le 23909 ) ) { $VulnStatus = "Appears Vulnerable" } } # Confirmed for Windows 2008
             7600 { if ( $Revision -ge 16000 ) { $VulnStatus = "Appears Vulnerable" } } # Not sure about 7 RTM
-            7601 { if ( ( $Revision -In 23000..23347 ) -Or ( $Revison -lt 19148 ) ) { $VulnStatus = "Appears Vulnerable" } } # Confirmed for Windows 7 and 2008R2
-            9200 { if ( ( $Revision -In 21000..21767 ) -Or ( $Revison -lt 17649 ) ) { $VulnStatus = "Appears Vulnerable" } } # Confirmed for Windows 2012
+            7601 { if ( $Revision -lt 19148 -Or ( $Revision -ge 23000 -And $Revision -le 23347 ) ) { $VulnStatus = "Appears Vulnerable" } } # Confirmed for Windows 7 and 2008R2
+            9200 { if ( $Revison -lt 17649 -Or ( $Revision -ge 21000 -And $Revision -le 21767 ) ) { $VulnStatus = "Appears Vulnerable" } } # Confirmed for Windows 2012
             9600 { if ( $Revison -lt 18230 ) { $VulnStatus = "Appears Vulnerable" } } # Confirmed for Windows 8.1 and 2012R2
             10240 { if ( $Revision -lt 16724 ) { $VulnStatus = "Appears Vulnerable" } } # Confirmed for Windows 10
             10586 { if ( $Revision -le 161 ) { $VulnStatus = "Appears Vulnerable" } } # Confirmed for Windows 10 1151

--- a/Sherlock.ps1
+++ b/Sherlock.ps1
@@ -129,7 +129,7 @@ function Find-MS10015 {
         # Decide which versions are vulnerable
         switch ( $Build ) {
 
-            7600 { if ( $Revision -le "20591" ) { $VulnStatus = "Appears Vulnerable" } }
+            7600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "20591" ] }
             default { $VulnStatus = "Not Vulnerable" }
 
         }
@@ -166,7 +166,7 @@ function Find-MS10092 {
         # Decide which versions are vulnerable
         switch ( $Build ) {
 
-            7600 { if ( $Revision -le "20830" ) { $VulnStatus = "Appears Vulnerable" } }
+            7600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "20830" ] }
             default { $VulnStatus = "Not Vulnerable" }
 
         }
@@ -211,9 +211,9 @@ function Find-MS13053 {
         # Decide which versions are vulnerable
         switch ( $Build ) {
 
-            7600 { if ( $Revision -ge "17000" ) { $VulnStatus = "Appears Vulnerable" } }
-            7601 { if ( $Revision -le "22348" ) { $VulnStatus = "Appears Vulnerable" } }
-            9200 { if ( $Revision -le "20732" ) { $VulnStatus = "Appears Vulnerable" } }
+            7600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -ge "17000" ] }
+            7601 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "22348" ] }
+            9200 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "20732" ] }
             default { $VulnStatus = "Not Vulnerable" }
 
         }
@@ -254,9 +254,9 @@ function Find-MS13081 {
         # Decide which versions are vulnerable
         switch ( $Build ) {
 
-            7600 { if ( $Revision -ge "18000" ) { $VulnStatus = "Appears Vulnerable" } }
-            7601 { if ( $Revision -le "22435" ) { $VulnStatus = "Appears Vulnerable" } }
-            9200 { if ( $Revision -le "20807" ) { $VulnStatus = "Appears Vulnerable" } }
+            7600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -ge "18000" ] }
+            7601 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "22435" ] }
+            9200 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "20807" ] }
             default { $VulnStatus = "Not Vulnerable" }
 
         }
@@ -293,10 +293,10 @@ function Find-MS14058 {
         # Decide which versions are vulnerable
         switch ( $Build ) {
 
-            7600 { if ( $Revision -ge "18000" ) { $VulnStatus = "Appears Vulnerable" } }
-            7601 { if ( $Revision -le "22823" ) { $VulnStatus = "Appears Vulnerable" } }
-            9200 { if ( $Revision -le "21247" ) { $VulnStatus = "Appears Vulnerable" } }
-            9600 { if ( $Revision -le "17353" ) { $VulnStatus = "Appears Vulnerable" } }
+            7600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -ge "18000" ] }
+            7601 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "22823" ] }
+            9200 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "21247" ] }
+            9600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "17353" ] }
             default { $VulnStatus = "Not Vulnerable" }
 
         }
@@ -337,10 +337,10 @@ function Find-MS15051 {
         # Decide which versions are vulnerable
         switch ( $Build ) {
 
-            7600 { if ( $Revision -ge "18000" ) { $VulnStatus = "Appears Vulnerable" } }
-            7601 { if ( $Revision -le "22823" ) { $VulnStatus = "Appears Vulnerable" } }
-            9200 { if ( $Revision -le "21247" ) { $VulnStatus = "Appears Vulnerable" } }
-            9600 { if ( $Revision -le "17353" ) { $VulnStatus = "Appears Vulnerable" } }
+            7600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -ge "18000" ] }
+            7601 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "22823" ] }
+            9200 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "21247" ] }
+            9600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "17353" ] }
             default { $VulnStatus = "Not Vulnerable" }
 
         }
@@ -413,12 +413,12 @@ function Find-MS16016 {
         # Decide which versions are vulnerable
         switch ( $Build ) {
 
-            7600 { if ( $Revision -ge "16000" ) { $VulnStatus = "Appears Vulnerable" } }
-            7601 { if ( $Revision -le "23317" ) { $VulnStatus = "Appears Vulnerable" } }
-            9200 { if ( $Revision -le "21738" ) { $VulnStatus = "Appears Vulnerable" } }
-            9600 { if ( $Revision -le "18189" ) { $VulnStatus = "Appears Vulnerable" } }
-            10240 { if ( $Revision -le "16683" ) { $VulnStatus = "Appears Vulnerable" } }
-            10586 { if ( $Revision -le "103" ) { $VulnStatus = "Appears Vulnerable" } }
+            7600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -ge "16000" ] }
+            7601 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "23317" ] }
+            9200 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "21738" ] }
+            9600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "18189" ] }
+            10240 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "16683" ] }
+            10586 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "103" ] }
             default { $VulnStatus = "Not Vulnerable" }
 
         }
@@ -431,7 +431,6 @@ function Find-MS16016 {
 }
 
 function Find-MS16032 {
-    echo "Moo"
     # Set the MS Bulletin
     $MSBulletin = "MS16-032"
 
@@ -450,20 +449,17 @@ function Find-MS16032 {
 
         # Get the Build and Revision
         $Build = [int]$VersionInfo[2]
-        $Revision = $VersionInfo[3].Split(" ")[0] # Drop the junk
-        echo $Build
-        echo $Revision
-        echo "----"
+        $Revision = [int]$VersionInfo[3].Split(" ")[0] # Drop the junk
         # Decide which versions are vulnerable
         switch ( $Build ) {
-            6002 { if ( $Revison -lt 19598 -Or ( $Revision -ge 23000 -And $Revision -le 23909 ) ) { $VulnStatus = "Appears Vulnerable" } } # Confirmed for Windows 2008
-            7600 { if ( $Revision -ge 16000 ) { $VulnStatus = "Appears Vulnerable" } } # Not sure about 7 RTM
-            7601 { if ( $Revision -lt 19148 -Or ( $Revision -ge 23000 -And $Revision -le 23347 ) ) { $VulnStatus = "Appears Vulnerable" } } # Confirmed for Windows 7 and 2008R2
-            9200 { if ( $Revison -lt 17649 -Or ( $Revision -ge 21000 -And $Revision -le 21767 ) ) { $VulnStatus = "Appears Vulnerable" } } # Confirmed for Windows 2012
-            9600 { if ( $Revison -lt 18230 ) { $VulnStatus = "Appears Vulnerable" } } # Confirmed for Windows 8.1 and 2012R2
-            10240 { if ( $Revision -lt 16724 ) { $VulnStatus = "Appears Vulnerable" } } # Confirmed for Windows 10
-            10586 { if ( $Revision -le 161 ) { $VulnStatus = "Appears Vulnerable" } } # Confirmed for Windows 10 1151
-            default { $VulnStatus = "Not Vulnerable" }
+            6002 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revison -lt 19598 -Or ( $Revision -ge 23000 -And $Revision -le 23909 ) ] } # Confirmed for Windows 2008
+            7600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -ge 16000 ] } # Not sure about 7 RTM
+            7601 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -lt 19148 -Or ( $Revision -ge 23000 -And $Revision -le 23347 ) ] } # Confirmed for Windows 7 and 2008R2
+            9200 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revison -lt 17649 -Or ( $Revision -ge 21000 -And $Revision -le 21767 ) ] } # Confirmed for Windows 2012
+            9600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revison -lt 18230 ] } # Confirmed for Windows 8.1 and 2012R2
+            10240 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -lt 16724 ] } # Confirmed for Windows 10
+            10586 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le 161 ] } # Confirmed for Windows 10 1151
+            default { $VulnStatus = "Not Vulnerable" } # If no match
 
         }
 

--- a/Sherlock.ps1
+++ b/Sherlock.ps1
@@ -449,18 +449,18 @@ function Find-MS16032 {
         $VersionInfo = $VersionInfo.Split(".")
 
         # Get the Build and Revision
-        $Build = $VersionInfo[2]
+        $Build = [int]$VersionInfo[2]
         $Revision = $VersionInfo[3].Split(" ")[0] # Drop the junk
 
         # Decide which versions are vulnerable
         switch ( $Build ) {
-
-            7600 { if ( $Revision -ge "16000" ) { $VulnStatus = "Appears Vulnerable" } }
-            7601 { if ( $Revision -le "23348" ) { $VulnStatus = "Appears Vulnerable" } }
-            9200 { if ( $Revision -le "21768" ) { $VulnStatus = "Appears Vulnerable" } }
-            9600 { if ( $Revision -le "18230" ) { $VulnStatus = "Appears Vulnerable" } }
-            10240 { if ( $Revision -le "16724" ) { $VulnStatus = "Appears Vulnerable" } }
-            10586 { if ( $Revision -le "162" ) { $VulnStatus = "Appears Vulnerable" } }
+            6002 { if ( ( $Revision -In 23000..23909 ) -Or ( $Revison -lt 19598 ) ) { $VulnStatus = "Appears Vulnerable" } } # Confirmed for Windows 2008
+            7600 { if ( $Revision -ge 16000 ) { $VulnStatus = "Appears Vulnerable" } } # Not sure about 7 RTM
+            7601 { if ( ( $Revision -In 23000..23347 ) -Or ( $Revison -lt 19148 ) ) { $VulnStatus = "Appears Vulnerable" } } # Confirmed for Windows 7 and 2008R2
+            9200 { if ( ( $Revision -In 21000..21767 ) -Or ( $Revison -lt 17649 ) ) { $VulnStatus = "Appears Vulnerable" } } # Confirmed for Windows 2012
+            9600 { if ( $Revison -lt 18230 ) { $VulnStatus = "Appears Vulnerable" } } # Confirmed for Windows 8.1 and 2012R2
+            10240 { if ( $Revision -lt 16724 ) { $VulnStatus = "Appears Vulnerable" } } # Confirmed for Windows 10
+            10586 { if ( $Revision -le 161 ) { $VulnStatus = "Appears Vulnerable" } } # Confirmed for Windows 10 1151
             default { $VulnStatus = "Not Vulnerable" }
 
         }


### PR DESCRIPTION
- Fixed version checks in MS16-032 based off http://plugins.openvas.org/nasl.php?oid=807309
- Fixed logic around $VulnStatus result as it was only returning if the switch block didn't evaluate, or if the switch evaluated but the subsequent if block was true.  If either the switch block evaluated, and the if block was false, then $VulnStatus was empty.